### PR TITLE
Allow calculated metrics to be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The API accepts several options (see the [Google Analytics developer docs](https
 * `startDate`: the start date for the report
 * `endDate`: the end date for the report
 * `queryIndividualDays`: fetches each day from the chosen date range individually in order to minimize sampling (only works if `date` is chosen as dimension)
+* `calculatedMetrics`: the suffixes of any calculated metrics (defined in your GA view) you want to query
 
 ### Scala API
 __Spark 1.4+:__
@@ -62,10 +63,11 @@ val df = sqlContext.read
     .option("startDate", "7daysAgo")
     .option("endDate", "yesterday")
     .option("queryIndividualDays", "true")
+    .option("calculatedMetrics", "averageEngagement")
     .load()
 
 // You need select the date column if using queryIndividualDays
-df.select("date", "browser", "city", "users").show()
+df.select("date", "browser", "city", "users", "calcMetric_averageEngagement").show()
 ```
 
 ## Building From Source

--- a/src/main/scala/com/crealytics/google/analytics/DefaultSource.scala
+++ b/src/main/scala/com/crealytics/google/analytics/DefaultSource.scala
@@ -31,6 +31,7 @@ class DefaultSource
     val analytics = new Analytics.Builder(httpTransport, jsonFactory, credential)
       .setApplicationName("spark-google-analytics")
       .build()
+    val calculatedMetrics = parameters.getOrElse("calculatedMetrics", "").split(",").map(_.trim)
     val queryIndividualDays: Boolean = parameters.getOrElse("queryIndividualDays", "false") == "true"
 
     AnalyticsRelation(
@@ -38,6 +39,7 @@ class DefaultSource
       parameters("ids"),
       parameters("startDate"),
       parameters("endDate"),
+      calculatedMetrics,
       queryIndividualDays
     )(sqlContext)
   }


### PR DESCRIPTION
This pull request adds support for calculated metric columns. Example of API below. Closes #9.

```scala
val df = spark.read
  .format("com.crealytics.google.analytics")
  // ... auth stuff ...
  .option("startDate", "2016-11-10")
  .option("endDate", "2016-11-14")
  .option("calculatedMetrics", "AverageEngagement, AnotherCoolMetric")
  .load()

display(df.select(
  col("pagePath"),
  col("calcMetric_AverageEngagement")
))
```